### PR TITLE
Re-add `package-initialize`

### DIFF
--- a/init-emacs.org
+++ b/init-emacs.org
@@ -51,6 +51,8 @@ use-package is not installed and afterwards make sure to have it
 installed and required.
 
 #+BEGIN_SRC emacs-lisp
+(package-initialize)
+
 (unless (package-installed-p 'use-package)
   (package-refresh-contents)
   (package-install 'use-package))


### PR DESCRIPTION
If call is missing, emacs doesn't start properly, throwing the
following error message:

`error: package.el is not yet initialized!`

Thanks for a great emacs configutation!